### PR TITLE
Reference removed also of fDependencyOrder, because had occured error…

### DIFF
--- a/Quick.IOC.pas
+++ b/Quick.IOC.pas
@@ -634,10 +634,13 @@ begin
   begin
     if (vValue.IntfInfo = aTypeInfo) and (vValue.Name = aName) then
     begin
+      if fDependencyOrder.Contains(vValue) then
+        fDependencyOrder.Remove(vValue);
       fDependencies.Remove(key);
       vValue.Free;
     end;
   end;
+
 end;
 
 { TIocResolver }


### PR DESCRIPTION
… of "invalid pointer operation" on destroy do IOC.